### PR TITLE
Ajout du choix du mode ftp passif/actif

### DIFF
--- a/lib/syncftp.rb
+++ b/lib/syncftp.rb
@@ -138,11 +138,12 @@ class SyncFTP
   # * +:remote+ : the remote directory (default = ".")
   #
   def sync( options = {} )
-    options = { :local => ".", :remote => "." }.merge( options )
-    local, remote = options[:local], options[:remote]
+    options = { :local => ".", :remote => "." , :passive => false}.merge( options )
+    local, remote , passive = options[:local], options[:remote], options[:passive]
     
     tmpname = tmpfilename
     connect do |ftp|
+      ftp.passive = passive
       # Read remote .syncftp
       begin
         ftp.gettextfile( remote+"/"+".syncftp", tmpname )


### PR DESCRIPTION
Bonjour,
J'utilise syncftp pour synchroniser un site généré par jekyll chez free.
Jusqu'à présent, j'avais des problème de stabilité de la connexion, qui étaient dus je pense au fait que la plupart des serveurs attendent une connexion de type 'passif' alors que la lib ruby standard positionne la connexion ftp en 'active'.

Un paramètre supplémentaire :passive => true permet de régler le problème, je peux maintenant uploader sans problème.

Merci !
